### PR TITLE
Simple debouncer/deglitcher for Atm_encoder.cpp

### DIFF
--- a/src/Atm_encoder.cpp
+++ b/src/Atm_encoder.cpp
@@ -44,7 +44,8 @@ void Atm_encoder::action( int id ) {
       enc_bits = ( ( enc_bits << 2 ) | ( digitalRead( pin1 ) << 1 ) | ( digitalRead( pin2 ) ) ) & 0x0f;
       enc_direction = enc_states[enc_bits];
       if ( enc_direction != 0 ) {
-        if ( ++enc_counter % divider == 0 ) {
+    	  enc_counter = enc_counter+enc_direction;
+        if ( (enc_counter != 0) && (enc_counter % divider == 0) ) {
           if ( !count( enc_direction ) ) {
             enc_direction = 0;
           }
@@ -59,6 +60,7 @@ void Atm_encoder::action( int id ) {
       return;
   }
 }
+
 
 Atm_encoder& Atm_encoder::range( int min, int max, bool wrap /* = false */ ) {
   if ( min > max ) {


### PR DESCRIPTION
The divisor of the Atm_encoder does not work as debouncer, because if the counter is reached it triggers the last read in direction.

Thus I changed the counter to count forwards and backwards and only  trigger the event if divisor is reached.
